### PR TITLE
dtype('o') is undefined fix

### DIFF
--- a/lab2/Classification.ipynb
+++ b/lab2/Classification.ipynb
@@ -265,7 +265,7 @@
    "source": [
     "def encode_numerically(df):\n",
     "    encoders = {}\n",
-    "    is_encodable = dtype('O')\n",
+    "    is_encodable = np.dtype('O')\n",
     "    dtypes = dict(df.dtypes)\n",
     "    for k, v in dtypes.items():\n",
     "        if v == is_encodable:\n",


### PR DESCRIPTION
Not sure if i am the getting this error because I manually imported packages, but dtype error was fixed by putting `np.` in front.

@InzamamRahaman For your review